### PR TITLE
Reverting FOV restrictions

### DIFF
--- a/cfg/rgl_base.cfg
+++ b/cfg/rgl_base.cfg
@@ -149,7 +149,6 @@ sv_turbophysics "1"                              // prevents people from moving 
 sv_alltalk "0"                                   // sets alltalk off
 sv_pausable "1"                                  // enables the ability to pause
 sv_allow_wait_command "0"                        // disables wait command
-sv_restrict_aspect_ratio_fov "2"                 // prevents fov cheating with huge ultrawide monitors
 sv_allow_color_correction "0"                    // disallow color correction
 sv_cacheencodedents "1"                          // according to developer.valvesoftware.com , "does an optimization to prevent extra SendTable_Encode calls."
 sv_forcepreload "1"                              // forces server to preload assets

--- a/cfg/rgl_base.cfg
+++ b/cfg/rgl_base.cfg
@@ -149,6 +149,7 @@ sv_turbophysics "1"                              // prevents people from moving 
 sv_alltalk "0"                                   // sets alltalk off
 sv_pausable "1"                                  // enables the ability to pause
 sv_allow_wait_command "0"                        // disables wait command
+sv_restrict_aspect_ratio_fov "1"                 // stays default
 sv_allow_color_correction "0"                    // disallow color correction
 sv_cacheencodedents "1"                          // according to developer.valvesoftware.com , "does an optimization to prevent extra SendTable_Encode calls."
 sv_forcepreload "1"                              // forces server to preload assets


### PR DESCRIPTION
It's nauseating to have to play with this setting as it only effects a minority of the player base the setting doesn't need to be enabled to restrict that vast minority within the community.

[Ultrawide examples.zip](https://github.com/RGLgg/server-resources-updater/files/14295158/Ultrawide.examples.zip)
