### PR TITLE
cfg/rgl_off: don't turn random damage spread back on

### DIFF
--- a/cfg/rgl_off.cfg
+++ b/cfg/rgl_off.cfg
@@ -101,7 +101,7 @@ host_framerate "0"                           // unlocks server framerate, essent
 
 tf_allow_taunt_switch "0"                    // disallows switching weapons during taunting (default)
 tf_avoidteammates_pushaway "1"               // enables stupid "pushing" of your own teammates, like in pubs
-tf_damage_disablespread "0"                  // disables damage spread (default)
+tf_damage_disablespread "1"                  // disables damage spread (default)
 tf_overtime_nag "0"                          // turns off the announcer freaking about about overtime. (default)
 tf_spells_enabled "0"                        // disables spells (default)
 tf_powerup_mode "0"                          // turns off mannpower mode if it's on for some reason. (default)


### PR DESCRIPTION
Random damage spread was disabled by default in Gun Mettle \[1\]. Update the default in rgl_off to match the default setting for the cvar in vanilla TF2 (this includes Casual).

\[1\]: https://www.teamfortress.com/gunmettle/powerhouse.php (section "GAME PLAY CHANGES")